### PR TITLE
Fixed errors caused by paths to files and removed un-needed & unused header files

### DIFF
--- a/src/commands/class_command.cpp
+++ b/src/commands/class_command.cpp
@@ -7,13 +7,13 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/class_command.h"
-#include "commands/fpair_command.h"
+#include "../../include/commands/class_command.h"
+#include "../../include/commands/fpair_command.h"
 
-#include "directory.h"
-#include "file.h"
-#include "logger.h"
-#include "misc.h"
+#include "../../include/directory.h"
+#include "../../include/file.h"
+#include "../../include/logger.h"
+#include "../../include/misc.h"
 
 #include <filesystem>
 

--- a/src/commands/command.cpp
+++ b/src/commands/command.cpp
@@ -7,7 +7,7 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/command.h"
+#include "../../include/commands/command.h"
 
 Logger &Command::logger = Logger::get();
 Data_Manager &Command::data_manager = Data_Manager::get();

--- a/src/commands/command_manager.cpp
+++ b/src/commands/command_manager.cpp
@@ -7,9 +7,9 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/command_manager.h"
-#include "logger.h"
-#include "misc.h"
+#include "../../include/commands/command_manager.h"
+#include "../../include/logger.h"
+#include "../../include/misc.h"
 
 #include <iostream>
 

--- a/src/commands/config_command.cpp
+++ b/src/commands/config_command.cpp
@@ -7,9 +7,9 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/config_command.h"
-#include "data.h"
-#include "logger.h"
+#include "../../include/commands/config_command.h"
+#include "../../include/data.h"
+#include "../../include/logger.h"
 
 /**
  * @brief Construct a new Config_Command object

--- a/src/commands/fpair_command.cpp
+++ b/src/commands/fpair_command.cpp
@@ -7,11 +7,11 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/fpair_command.h"
+#include "../../include/commands/fpair_command.h"
 
-#include "directory.h"
-#include "file.h"
-#include "misc.h"
+#include "../../include/directory.h"
+#include "../../include/file.h"
+#include "../../include/misc.h"
 
 /**
  * @brief Construct a new Fpair_Command object

--- a/src/commands/init_command.cpp
+++ b/src/commands/init_command.cpp
@@ -7,14 +7,12 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/init_command.h"
+#include "../../include/commands/init_command.h"
 
-#include "config.h"
-#include "directory.h"
-#include "file.h"
-#include "misc.h"
-
-#include <fstream>
+#include "../../include/config.h"
+#include "../../include/directory.h"
+#include "../../include/file.h"
+#include "../../include/misc.h"
 
 /**
  * @brief Construct a new Init_Command object

--- a/src/commands/struct_command.cpp
+++ b/src/commands/struct_command.cpp
@@ -7,12 +7,12 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/struct_command.h"
-#include "commands/fpair_command.h"
+#include "../../include/commands/struct_command.h"
+#include "../../include/commands/fpair_command.h"
 
-#include "directory.h"
-#include "file.h"
-#include "misc.h"
+#include "../../include/directory.h"
+#include "../../include/file.h"
+#include "../../include/misc.h"
 
 #include <filesystem>
 

--- a/src/commands/version_command.cpp
+++ b/src/commands/version_command.cpp
@@ -7,9 +7,9 @@
  * @copyright Copyright (c) 2025
  *
  */
-#include "commands/version_command.h"
+#include "../../include/commands/version_command.h"
 
-#include "config.h"
+#include "../../include/config.h"
 
 /**
  * @brief Construct a new Version_Command object

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -7,9 +7,9 @@
  * @copyright Copyright (c) 2024
  *
  */
-#include "data.h"
-#include "directory.h"
-#include "misc.h"
+#include "../include/data.h"
+#include "../include/directory.h"
+#include "../include/misc.h"
 
 #include <cstdlib>
 #include <fstream>

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -7,10 +7,7 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include "directory.h"
-#include "logger.h"
-#include "misc.h"
-
+#include "../include/directory.h"
 #include <algorithm>
 
 namespace directory {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -8,9 +8,8 @@
  *
  */
 
-#include "file.h"
-#include "logger.h"
-#include "misc.h"
+#include "../include/file.h"
+#include "../include/misc.h"
 
 /**
  * @brief Construct a new File:: File object

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -7,7 +7,7 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include "logger.h"
+#include "../include/logger.h"
 
 #include <cstdint>
 #include <cstdlib>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,22 +7,21 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include "data.h"
-#include "directory.h"
-#include "logger.h"
-#include "misc.h"
+#include "../include/data.h"
+#include "../include/directory.h"
+#include "../include/logger.h"
+#include "../include/misc.h"
 
-#include "commands/class_command.h"
-#include "commands/command_manager.h"
-#include "commands/config_command.h"
-#include "commands/fpair_command.h"
-#include "commands/init_command.h"
-#include "commands/struct_command.h"
-#include "commands/version_command.h"
+#include "../include/commands/class_command.h"
+#include "../include/commands/command_manager.h"
+#include "../include/commands/config_command.h"
+#include "../include/commands/fpair_command.h"
+#include "../include/commands/init_command.h"
+#include "../include/commands/struct_command.h"
+#include "../include/commands/version_command.h"
 
 #include <chrono>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -7,8 +7,8 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include "misc.h"
-#include "logger.h"
+#include "../include/misc.h"
+#include "../include/logger.h"
 
 #include <algorithm>
 #include <cstdlib>


### PR DESCRIPTION
Errors were caused in my editors saying the paths were wrong so I fixed them and removed non-used ones. I could be wrong but I think everything works, please fact check before hand. and bazinga, this contribution did little to nothing so sorry